### PR TITLE
Fix bug with jumper sometimes stopped at the start

### DIFF
--- a/experimental/skijump-js/sj-objects/sj-Jumper.js
+++ b/experimental/skijump-js/sj-objects/sj-Jumper.js
@@ -64,6 +64,8 @@ class {
 
     this.flyState = this.FLY_S.JUMP;
   
+    this.isSlowingDown = false;
+
     this.walkSystem = new SJ.StartWalkSystem();
   
     this.offsetAngle = 0;

--- a/experimental/skijump-js/sj-spacejump.js
+++ b/experimental/skijump-js/sj-spacejump.js
@@ -5,7 +5,7 @@ const SJ = {};
 SJ.UI = {};
 
 // Game Version
-SJ.VERSION = "0.27.3";
+SJ.VERSION = "0.27.4";
 
 // Screen resolution
 SJ.SCREEN_WIDTH = 1200;
@@ -73,10 +73,10 @@ function setup() {
 
     SJ.ScreensManager.setup();
 
-    SJ._enterScreen(SJ.ScreensManager.screens.mainMenu);
+    // SJ._enterScreen(SJ.ScreensManager.screens.mainMenu);
     // SJ._enterScreen(SJ.ScreensManager.screens.shop);
     // SJ._startGame("TitanBase");
-    // SJ._startGame("CyberCity");
+    SJ._startGame("CyberCity");
     // SJ._startGame("StarStation");
   }); 
 }


### PR DESCRIPTION
The problem appears when jumper started "slowing down" (at the and of the launch pad). There was variable on jumper: `isSlowingDown`, that was set to true then, but wasn't reset to false, on `reset` method call, so jumper starts slowing down before it takes any velocity.

Added just one line to fix that.